### PR TITLE
simplify capacity evaluation

### DIFF
--- a/scripts/openrc/n900-pm
+++ b/scripts/openrc/n900-pm
@@ -154,14 +154,7 @@ check_status() {
 	idle=$(grep ^core_pwrdm /sys/kernel/debug/pm_debug/count | cut -d',' -f2,3)
 	uw=$(cat /sys/class/power_supply/bq27200-0/power_avg)
 	mw=$((${uw} / 1000))
-	if [ -f /sys/class/power_supply/bq27200-0/capacity ]; then
-	        cap=$(cat /sys/class/power_supply/bq27200-0/capacity 2>/dev/null)
-	        if [ "${cap}" = "" ]; then
-		                cap="NA"
-	        fi
-	else
-	        cap=0
-	fi
+	cap=$(cat /sys/class/power_supply/bq27200-0/capacity)
 	if [ "${reg_read_cmd}" = "" ]; then
 	        init_reg_read
 	fi


### PR DESCRIPTION
Directly use capacity value returned by kernel, because driver no longer returns -ENODATA when battery is not calibrated. This was implemented in upstream linux commit [68fdbe090c](https://github.com/torvalds/linux/commit/68fdbe090c362e8be23890a7333d156e18c27781) ("power: supply: bq27xxx: expose battery data when CI=1").